### PR TITLE
Add benchmarks for ColorWriter

### DIFF
--- a/internal/writer/writer_test.go
+++ b/internal/writer/writer_test.go
@@ -8,6 +8,7 @@ import (
 // cSpell:ignore mred mgreen
 var buffer = []byte("\x1b[31mred\x1b[0;32mgreen\x1b[0m\n")
 
+//nolint:errcheck
 func BenchmarkColorWriter_Write(b *testing.B) {
 	w := NewWriter(&bytes.Buffer{})
 	for i := 0; i < b.N; i++ {
@@ -15,6 +16,7 @@ func BenchmarkColorWriter_Write(b *testing.B) {
 	}
 }
 
+//nolint:errcheck
 func BenchmarkColorWriter_WriteColor(b *testing.B) {
 	w := NewWriter(&bytes.Buffer{})
 	w.SetTTY(func() bool { return true })

--- a/internal/writer/writer_test.go
+++ b/internal/writer/writer_test.go
@@ -5,6 +5,24 @@ import (
 	"testing"
 )
 
+// cSpell:ignore mred mgreen
+var buffer = []byte("\x1b[31mred\x1b[0;32mgreen\x1b[0m\n")
+
+func BenchmarkColorWriter_Write(b *testing.B) {
+	w := NewWriter(&bytes.Buffer{})
+	for i := 0; i < b.N; i++ {
+		w.Write(buffer)
+	}
+}
+
+func BenchmarkColorWriter_WriteColor(b *testing.B) {
+	w := NewWriter(&bytes.Buffer{})
+	w.SetTTY(func() bool { return true })
+	for i := 0; i < b.N; i++ {
+		w.Write(buffer)
+	}
+}
+
 func TestColorWriter_Write(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
Ran it against a few differnet orders for the switch cases and saw no consistent, significant difference.
