### PR TITLE
Change `Console` to an interface

### DIFF
--- a/console.go
+++ b/console.go
@@ -10,7 +10,23 @@ import (
 	"github.com/mattn/go-isatty"
 )
 
-type Console struct {
+type Console interface {
+	Stdout() io.Writer
+	Stderr() io.Writer
+	Stdin() io.Reader
+	IsStdoutTTY() bool
+	IsStderrTTY() bool
+	IsStdinTTY() bool
+
+	io.Writer
+
+	ColorScheme() *colorscheme.ColorScheme
+
+	StartProgress(label string, opts ...ProgressOption)
+	StopProgress()
+}
+
+type con struct {
 	stdout io.Writer
 	stderr io.Writer
 	stdin  io.Reader
@@ -26,8 +42,8 @@ type Console struct {
 	progressLock    sync.Mutex
 }
 
-func System() *Console {
-	c := &Console{
+func System() Console {
+	c := &con{
 		stdout: os.Stdout,
 		stderr: os.Stderr,
 		stdin:  os.Stdin,
@@ -40,11 +56,11 @@ func System() *Console {
 	return c
 }
 
-func (c *Console) Stdout() io.Writer {
+func (c *con) Stdout() io.Writer {
 	return c.stdout
 }
 
-func (c *Console) IsStdoutTTY() bool {
+func (c *con) IsStdoutTTY() bool {
 	if c.stdoutOverride != nil {
 		return *c.stdoutOverride
 	}
@@ -56,11 +72,11 @@ func (c *Console) IsStdoutTTY() bool {
 	return false
 }
 
-func (c *Console) Stderr() io.Writer {
+func (c *con) Stderr() io.Writer {
 	return c.stderr
 }
 
-func (c *Console) IsStderrTTY() bool {
+func (c *con) IsStderrTTY() bool {
 	if c.stderrOverride != nil {
 		return *c.stderrOverride
 	}
@@ -72,11 +88,11 @@ func (c *Console) IsStderrTTY() bool {
 	return false
 }
 
-func (c *Console) Stdin() io.Reader {
+func (c *con) Stdin() io.Reader {
 	return c.stdin
 }
 
-func (c *Console) IsStdinTTY() bool {
+func (c *con) IsStdinTTY() bool {
 	if c.stdinOverride != nil {
 		return *c.stdinOverride
 	}
@@ -89,11 +105,11 @@ func (c *Console) IsStdinTTY() bool {
 }
 
 // Write implements Writer on the console and calls Write on Stdout.
-func (c *Console) Write(p []byte) (n int, err error) {
+func (c *con) Write(p []byte) (n int, err error) {
 	return c.stdout.Write(p)
 }
 
 // ColorScheme gets the color scheme for the console i.e., Stdout.
-func (c *Console) ColorScheme() *colorscheme.ColorScheme {
+func (c *con) ColorScheme() *colorscheme.ColorScheme {
 	return c.cs
 }

--- a/console_test.go
+++ b/console_test.go
@@ -28,13 +28,13 @@ func testIsTTY(s string, t *testing.T) {
 
 	defer f.Close()
 
-	con := &Console{
+	console := &con{
 		stdout: f,
 		stderr: f,
 		stdin:  f,
 	}
 
-	getter := reflect.ValueOf(con).MethodByName("Is" + s + "TTY")
+	getter := reflect.ValueOf(console).MethodByName("Is" + s + "TTY")
 
 	// Default should evaluate handle, fail, and return false.
 	if getter.Call(emptyValues)[0].Bool() {

--- a/example_test.go
+++ b/example_test.go
@@ -32,7 +32,8 @@ func Example() {
 	}
 
 	// Doubly escape fake stdout and write to real stdout to assert output.
-	s := strings.ReplaceAll(fake.Stdout().String(), "\x1b", `\x1b`)
+	stdout, _, _ := fake.Buffers()
+	s := strings.ReplaceAll(stdout.String(), "\x1b", `\x1b`)
 	fmt.Println(s)
 
 	// Output: \x1b[0;31mred\x1b[0m\x1b[0;32mgreen\x1b[0m
@@ -50,7 +51,9 @@ func ExampleFake() {
 	// Create fake console from buffers.
 	fake := console.Fake()
 	fmt.Fprintf(fake.Stdout(), "Hello, fake!")
-	fmt.Println(fake.Stdout().String())
+
+	stdout, _, _ := fake.Buffers()
+	fmt.Println(stdout.String())
 
 	// Output: Hello, fake!
 }
@@ -74,7 +77,8 @@ func ExampleConsole_ColorScheme() {
 	fmt.Fprintf(fake.Stderr(), "%s\n", cs.Red("Error: red alert!"))
 
 	// Doubly escape fake stdout and write to real stdout to assert output.
-	s := strings.ReplaceAll(fake.Stderr().String(), "\x1b", `\x1b`)
+	_, stderr, _ := fake.Buffers()
+	s := strings.ReplaceAll(stderr.String(), "\x1b", `\x1b`)
 	fmt.Println(s)
 
 	// Output:

--- a/fake.go
+++ b/fake.go
@@ -7,13 +7,13 @@ import (
 )
 
 type FakeConsole struct {
-	*Console
+	*con
 }
 
 type FakeOption func(*FakeConsole)
 
 func Fake(opts ...FakeOption) *FakeConsole {
-	c := &Console{
+	c := &con{
 		stdout: &bytes.Buffer{},
 		stderr: &bytes.Buffer{},
 		stdin:  &bytes.Buffer{},
@@ -32,16 +32,11 @@ func Fake(opts ...FakeOption) *FakeConsole {
 	return f
 }
 
-func (f *FakeConsole) Stdout() *bytes.Buffer {
-	return f.stdout.(*bytes.Buffer)
-}
-
-func (f *FakeConsole) Stderr() *bytes.Buffer {
-	return f.stderr.(*bytes.Buffer)
-}
-
-func (f *FakeConsole) Stdin() *bytes.Buffer {
-	return f.stdin.(*bytes.Buffer)
+func (f *FakeConsole) Buffers() (stdout, stderr, stdin *bytes.Buffer) {
+	stdout = f.stdout.(*bytes.Buffer)
+	stderr = f.stderr.(*bytes.Buffer)
+	stdin = f.stdin.(*bytes.Buffer)
+	return
 }
 
 func (f *FakeConsole) Write(p []byte) (n int, err error) {

--- a/fake_test.go
+++ b/fake_test.go
@@ -21,7 +21,9 @@ func TestWithStdinTTY(t *testing.T) {
 func TestFakeConsole_Write(t *testing.T) {
 	f := Fake()
 	fmt.Fprintf(f, "test")
-	if got := f.Stdout().String(); got != "test" {
+
+	stdout, _, _ := f.Buffers()
+	if got := stdout.String(); got != "test" {
 		t.Fatalf(`Write() wrote %q, expected "test"`, got)
 	}
 }
@@ -35,12 +37,13 @@ func TestFakeConsole_StartProgress(t *testing.T) {
 	fmt.Fprintf(f, "test")
 	f.StopProgress()
 
-	if got := f.Stdout().String(); got != "test" {
+	stdout, stderr, _ := f.Buffers()
+	if got := stdout.String(); got != "test" {
 		t.Fatalf(`Write() wrote %q, expected "test"`, got)
 	}
 
 	// github.com/briandowns/spinner@v1.18.1 always checks os.Stdout so this will never fail.
-	if f.Stderr().Len() > 0 {
+	if stderr.Len() > 0 {
 		t.Fatalf(`StartProgress() wrote progress, expected none`)
 	}
 }

--- a/pkg/colorscheme/example_test.go
+++ b/pkg/colorscheme/example_test.go
@@ -17,7 +17,9 @@ func ExampleColorScheme() {
 
 	greeting := cs.ColorFunc("green")
 	fmt.Fprintf(fake.Stdout(), "%s", greeting("Hello, world!"))
-	fmt.Println(fake.Stdout().String())
+
+	stdout, _, _ := fake.Buffers()
+	fmt.Println(stdout.String())
 
 	// Output: Hello, world!
 }
@@ -35,7 +37,8 @@ func ExampleColorScheme_color() {
 	fmt.Fprintf(fake.Stdout(), "%s", greeting("Hello, world!"))
 
 	// Doubly escape fake stdout and write to real stdout to assert output.
-	s := strings.ReplaceAll(fake.Stdout().String(), "\x1b", `\x1b`)
+	stdout, _, _ := fake.Buffers()
+	s := strings.ReplaceAll(stdout.String(), "\x1b", `\x1b`)
 	fmt.Println(s)
 
 	// Output: \x1b[0;32mHello, world!\x1b[0m

--- a/progress.go
+++ b/progress.go
@@ -16,7 +16,7 @@ const (
 
 type ProgressOption func(*spinner.Spinner)
 
-func (c *Console) StartProgress(label string, opts ...ProgressOption) {
+func (c *con) StartProgress(label string, opts ...ProgressOption) {
 	if !c.progressEnabled || !c.IsStderrTTY() {
 		return
 	}
@@ -42,7 +42,7 @@ func (c *Console) StartProgress(label string, opts ...ProgressOption) {
 	c.progress = sp
 }
 
-func (c *Console) StopProgress() {
+func (c *con) StopProgress() {
 	c.progressLock.Lock()
 	defer c.progressLock.Unlock()
 


### PR DESCRIPTION
Couldn't actually assign a FakeConsole to a Console, so this was necessary for testing in heaths/gh-projets.
